### PR TITLE
Fix tags on an article in articles list

### DIFF
--- a/src/Web/Shared/TagsList.razor
+++ b/src/Web/Shared/TagsList.razor
@@ -12,8 +12,14 @@
 
     private List<string> Tags = new List<string>();
 
-    protected override void OnInitialized()
+    protected override void OnParametersSet()
     {
+        SetUp();
+    }
+
+    private void SetUp()
+    {
+        Tags.Clear();
         Categories = Categories.TrimEnd(',');
         var cats = Categories.Split(',');
         foreach (var cat in cats)


### PR DESCRIPTION
Fix tags on an article in articles list not loading the correct tag when paged, currently the state of tag is from the article on the last page.

Fixes martinkearn/MartinK-Me#97